### PR TITLE
Maintenance for v5.17.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ Releases
 Makefile
 blib
 pm_to_blib
+MYMETA.json
+MYMETA.yml

--- a/lib/Regexp/Common/balanced.pm
+++ b/lib/Regexp/Common/balanced.pm
@@ -28,6 +28,8 @@ sub nested {
 
     push @finishes => ($finishes [-1]) x (@starts - @finishes);
 
+    use re 'eval';
+
     my @re;
     local $" = "|";
     foreach my $begin (@starts) {
@@ -40,8 +42,6 @@ sub nested {
 
         my $tb  = quotemeta substr $begin => 1;
         my $te  = quotemeta substr $end   => 1;
-
-        use re 'eval';
 
         my $add;
         if ($fb eq $fe) {

--- a/t/test_delimited.t
+++ b/t/test_delimited.t
@@ -12,7 +12,7 @@ ok;
 if ($] >= 5.006) {
     # This gives a 'panic: POPSTACK' in 5.005_*
     eval {"" =~ $RE {delimited}};
-    ok $@ =~ /Must specify delimiter in \$RE{delimited}/;
+    ok $@ =~ /Must specify delimiter in \$RE\{delimited\}/;
 }
 
 try $RE {delimited} {-delim => ' '};

--- a/t/test_i.t
+++ b/t/test_i.t
@@ -57,6 +57,7 @@ foreach my $data (@data) {
 
     foreach my $str (@$queries) {
         local $" = "}{";
+        use re 'eval';
         eval "\$str =~ /^\$RE{@$name}{-i}\$/
                     ? pass \$str, '\$RE{@$name}{-i}'
                     : fail \$str, '\$RE{@$name}{-i}'";


### PR DESCRIPTION
Hi Abigail!

These patches make Regexp::Common work again with Perl 5.17.x.

If they are stupid, tell me.

If you are too busy for a CPAN release, feel free to
give me co-maint (cpan:SCHWIGON) and I take care of it.

Thanks!

Kind regards,
Steffen