### PR TITLE
Make delimited handle $esc\s

### DIFF
--- a/lib/Regexp/Common/delimited.pm
+++ b/lib/Regexp/Common/delimited.pm
@@ -38,7 +38,7 @@ sub gen_delimited {
         }
         elsif (length $esc) {
             push @pat =>
-                "(?k:$del)(?k:[^$esc$cdel]*(?:$esc.[^$esc$cdel]*)*)(?k:$cdel)";
+                "(?k:$del)(?k:[^$esc$cdel]*(?s:$esc.[^$esc$cdel]*)*)(?k:$cdel)";
         }
         else {
             push @pat => "(?k:$del)(?k:[^$cdel]*)(?k:$cdel)";


### PR DESCRIPTION
I was surprised that `"'\n'" =~ /$RE{quoted}/` succeeds but `"'\\\n'" =~ /$RE{quoted}/` fails, unless I explicitly add the `s` modifier (`"'\\\n'" =~ /$RE{quoted}/s`).

I gather the problem is that, while a `$RE{delimited}` can generally contain any characters except `$esc` and `$cdel`, it can only contain `.` in the position following `$esc`, which doesn't include `\n` (without the `s` modifier).

Should `$RE{delimited}` add the `s` modifier itself?